### PR TITLE
Add release to map feature properties

### DIFF
--- a/wazimap_za/static/js/maps_mapit.js
+++ b/wazimap_za/static/js/maps_mapit.js
@@ -73,6 +73,9 @@ function MapItGeometryLoader() {
         feature.properties.level = feature.properties.type_name.toLowerCase();
         feature.properties.code = feature.properties.codes.MDB;
         feature.properties.geoid = feature.properties.level + '-' + feature.properties.code;
+        if (RELEASE && RELEASE != "") {
+            feature.properties.release = RELEASE;
+        }
     };
 
     this.loadGeometryForLevel = function(level, geo_version, success) {


### PR DESCRIPTION
This allows us to keep the current release when navigating by clicking on a geo in the map