### PR TITLE
Remove release from mape feature properties

### DIFF
--- a/wazimap_za/static/js/maps_mapit.js
+++ b/wazimap_za/static/js/maps_mapit.js
@@ -73,9 +73,6 @@ function MapItGeometryLoader() {
         feature.properties.level = feature.properties.type_name.toLowerCase();
         feature.properties.code = feature.properties.codes.MDB;
         feature.properties.geoid = feature.properties.level + '-' + feature.properties.code;
-        if (RELEASE && RELEASE != "") {
-            feature.properties.release = RELEASE;
-        }
     };
 
     this.loadGeometryForLevel = function(level, geo_version, success) {


### PR DESCRIPTION
This change was causing issues when viewing the latest release of a geo_level with all the release years, and navigating to a geo_level which didn't have the the latest release.

This is just a revert so as to fix the error pages until we do this better.