### PR TITLE
Import data, then run migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ create database wazimap_<instance_name>;
 grant all privileges on database wazimap_<instance_name> to wazimap_<instance_name>;
 ```
 
+Import the data into the new database.
+```
+cat sql/*.sql | psql -U wazimap_<instance_name> -W wazimap_<instance_name>
+```
+
 Run migrations to keep Django happy:
 ```
 python manage.py migrate
-```
-
-Import the data into the new database (will overwrite some tables created by Django, but that's ok).
-```
-cat sql/*.sql | psql -U wazimap_<instance_name> -W wazimap_<instance_name>
 ```
 
 Import the fixtures for the django models:


### PR DESCRIPTION
@longhotsummer  @ebsuku 

I remember we had issues with this in the past too. Migrations can't be run before we have tables in the DB, and I think the old instructions assumed these tables already exist.